### PR TITLE
Don't change ENV['RAILS_ENV'] in the guard process

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -41,6 +41,16 @@ module Guard
       "sh -c 'cd \"#{@root}\" && #{command} &'"
     end
 
+    def environment
+      rails_env = if options[:zeus]
+                    nil
+                  else
+                    options[:environment]
+                  end
+
+      { "RAILS_ENV" => rails_env }
+    end
+
     def pid_file
       File.expand_path(options[:pid_file] || File.join(@root, "tmp/pids/#{options[:environment]}.pid"))
     end
@@ -78,19 +88,15 @@ module Guard
         options[:zeus_plan] || 'server',
       ]
 
-      # To avoid warning of Zeus
-      # Since setup RAILS_ENV is useless for Zeus
-      ENV['RAILS_ENV'] = nil
       "zeus #{zeus_options.join(' ')} #{build_options}"
     end
 
     def build_rails_command
-      ENV['RAILS_ENV'] = options[:environment] if options[:environment]
       "rails server #{build_options}"
     end
 
     def run_rails_command!
-      system build_command
+      system environment, build_command
     end
 
     def has_pid?

--- a/spec/lib/guard/rails/runner_spec.rb
+++ b/spec/lib/guard/rails/runner_spec.rb
@@ -164,6 +164,28 @@ describe Guard::RailsRunner do
     end
   end
 
+  describe '#environment' do
+    it "defaults RAILS_ENV to development" do
+      runner.environment["RAILS_ENV"].should == "development"
+    end
+
+    context "with options[:environment]" do
+      let(:options) { default_options.merge(:environment => 'bob') }
+
+      it "defaults RAILS_ENV to nil" do
+        runner.environment["RAILS_ENV"].should == "bob"
+      end
+
+      context "zeus enabled" do
+        let(:options) { default_options.merge(:zeus => true) }
+
+        it "should set RAILS_ENV to nil" do
+          runner.environment["RAILS_ENV"].should be_nil
+        end
+      end
+    end
+  end
+
   describe '#start' do
     let(:kill_expectation) { runner.expects(:kill_unmanaged_pid!) }
     let(:pid_stub) { runner.stubs(:has_pid?) }


### PR DESCRIPTION
We were seeing problems when running our RSpec tests via guard-rspec after guard-rails had booted Rails.

Now we use the optional first parameter to Kernel#system to set the environment only for the launched process.
