### PR TITLE
backwards compatibility for the environment parameter

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -96,7 +96,7 @@ module Guard
     end
 
     def run_rails_command!
-      system environment, build_command
+      system "#{environment.collect {|k,v| "#{k}=#{v} "}.join} #{build_command}"
     end
 
     def has_pid?


### PR DESCRIPTION
A small tweak which will allow people still on Ruby 1.8.7 to continue to use guard-rails
