### PR TITLE
Windows fixes: Environment variables in command line; Redirecting to null device

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -24,7 +24,7 @@ module Guard
         wait_for_no_pid if $?.exitstatus == 0
 
         # If you lost your pid_file, you are already died.
-        system "kill -KILL #{pid} >&2 2>/dev/null"
+        system "kill -KILL #{pid} >&2 2>#{::Guard::DEV_NULL}"
         FileUtils.rm pid_file, :force => true
       end
     end
@@ -38,7 +38,7 @@ module Guard
       command = build_cli_command if options[:CLI]
       command ||= build_zeus_command if options[:zeus]
       command ||= build_rails_command
-      "sh -c 'cd \"#{@root}\" && #{command} &'"
+      "#{environment.collect {|k,v| "#{k}=#{v} "}.join} cd \"#{@root}\" && #{command}"
     end
 
     def environment
@@ -96,7 +96,7 @@ module Guard
     end
 
     def run_rails_command!
-      system "#{environment.collect {|k,v| "#{k}=#{v} "}.join} #{build_command}"
+      system "sh -c 'cd \"#{@root}\" && #{build_command} &'"
     end
 
     def has_pid?


### PR DESCRIPTION
- On Windows platforms, calls to Kernel#system issues commands to Windows Command Interpreter (cmd.exe). Windows Command Interpreter does not support setting of environment variables at the beginning of a command. This pull request moves the setting of environment variables inside the command string passed to sh where environment variables are processed as expected.
- Replace use of '/dev/null' with Guard::DEV_NULL, a constant that is evaluated at load time Guard is loaded (see guard/guard#365). The constant is set 'NUL' on Windows to '/dev/null' on other platforms.
