### PR TITLE
Use two parameter form of #system to avoid setting environment variables...

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -38,7 +38,7 @@ module Guard
       command = build_cli_command if options[:CLI]
       command ||= build_zeus_command if options[:zeus]
       command ||= build_rails_command
-      "#{environment.collect {|k,v| "#{k}=#{v} "}.join} cd \"#{@root}\" && #{command}"
+      "sh -c 'cd \"#{@root}\" && #{command} &'"
     end
 
     def environment
@@ -96,7 +96,7 @@ module Guard
     end
 
     def run_rails_command!
-      system "sh -c 'cd \"#{@root}\" && #{build_command} &'"
+      system(environment, build_command)
     end
 
     def has_pid?


### PR DESCRIPTION
... on the command line
- Partially reverts d02a01711c9b4e8fb5e402fc832d29bcc7a95e02
- Avoids setting environment variables as a command prefix which is not supported by the Windows command processor
