### PR TITLE
Use the correct option name in initialization: s/:force_runs/:force_run/

### DIFF
--- a/lib/guard/rails.rb
+++ b/lib/guard/rails.rb
@@ -15,7 +15,7 @@ module Guard
       :daemon => false,
       :debugger => false,
       :environment => 'development',
-      :force_runs => false,
+      :force_run => false,
       :pid_file => nil, # construct the filename based on options[:environment] on runtime
       :port => 3000,
       :server => nil, # specified by rails


### PR DESCRIPTION
Referenced as :force_runs only in this one place. Referenced as :force_run in three places:
  ./lib/guard/rails/runner.rb:15
  ./README.md:37
  ./spec/lib/guard/rails/runner_spec.rb:210

No functionality changes as a result of this fix. Just a typo fix/clean up.
