### PR TITLE
add restart_done hook

### DIFF
--- a/lib/guard/rails.rb
+++ b/lib/guard/rails.rb
@@ -42,6 +42,7 @@ module Guard
       UI.info title
       Notifier.notify("Rails #{action}ing on port #{options[:port]} in #{options[:environment]}...", :title => title, :image => :pending)
       if runner.restart
+        hook "restart_done"
         UI.info "Rails #{action}ed, pid #{runner.pid}"
         Notifier.notify("Rails #{action}ed on port #{options[:port]}.", :title => "Rails #{action}ed!", :image => :success)
       else


### PR DESCRIPTION
This allows me to be able to livereload on backend changes:

```
guard 'rails', daemon: true, pid_file: 'rack.pid', CLI: 'bundle exec rackup -p 3000 -s thin -P rack.pid' do
  watch('Gemfile.lock')
  watch('config.ru')
  watch('app.rb')
  callback(:restart_done) {  Guard.plugins.find {|p| p.class == LiveReload}.reactor.reload_browser(["whatever"]) }
end
```

I didn't include specs as I'm not sure how to test this. If you have any pointers it would be much appreciated.

Cheers,
