### PR TITLE
Enable to work with guard-process

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -166,7 +166,7 @@ module Guard
 
       def kill_process(signal, pid)
         begin
-          Process.kill(signal, pid)
+          ::Process.kill(signal, pid)
           true
         rescue Errno::EPERM
           UI.info "[Guard::Rails::Error] Don't have permission to KILL!"


### PR DESCRIPTION
Hi, @ranmocy 

I encountered an issue on using guard-rails with guard-process.

`Process` resolved to `Guard::Process` when guard-process has enabled.
