### PR TITLE
Block startup until zeus sockfile is present if zeus option is specified

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -14,6 +14,7 @@ module Guard
 
       def start
         kill_unmanaged_pid! if options[:force_run]
+        wait_for_zeus if options[:zeus]
         run_rails_command!
         wait_for_pid
       end
@@ -65,6 +66,11 @@ module Guard
         options[:timeout].to_f / MAX_WAIT_COUNT.to_f
       end
 
+      def wait_for_zeus
+        sleep(1) until File.exist?(zeus_sockfile)
+        File.exist?(zeus_sockfile)
+      end
+
       private
 
       # command builders
@@ -84,6 +90,10 @@ module Guard
 
       def build_cli_command
         "#{options[:CLI]} --pid \"#{pid_file}\""
+      end
+
+      def zeus_sockfile
+        File.join(Dir.pwd, '.zeus.sock')
       end
 
       def build_zeus_command

--- a/spec/lib/guard/rails/runner_spec.rb
+++ b/spec/lib/guard/rails/runner_spec.rb
@@ -463,4 +463,20 @@ describe Guard::Rails::Runner do
       expect(runner.sleep_time).to eq (timeout.to_f / Guard::Rails::Runner::MAX_WAIT_COUNT.to_f)
     end
   end
+
+  describe '#wait_for_zeus' do
+    context 'with options[:zeus]' do
+      before do
+        FileUtils.touch File.join(Dir.pwd, '.zeus.sock')
+      end
+
+      after do
+        FileUtils.rm File.join(Dir.pwd, '.zeus.sock')
+      end
+
+      it "waits until the zeus socket file to be present" do
+        expect(runner.wait_for_zeus).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Basically poll for the zeus socket file before starting the guard so app startup doesn't fail.