### PR TITLE
Support Zeus in Rails Engine dummy apps

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -191,7 +191,14 @@ module Guard
       end
 
       def zeus_sockfile
-        File.join(@root, '.zeus.sock')
+        return @zeus_sockfile_path unless @zeus_sockfile_path.nil?
+        root_sockfile_path = File.join @root, '.zeus.sock'
+        @zeus_sockfile_path = if File.exist?(root_sockfile_path)
+                                root_sockfile_path
+                              else
+                                pwd_sockfile_path = File.join Dir.pwd, '.zeus.sock'
+                                pwd_sockfile_path if File.exist?(pwd_sockfile_path)
+                              end
       end
 
     end

--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -191,14 +191,13 @@ module Guard
       end
 
       def zeus_sockfile
-        return @zeus_sockfile_path unless @zeus_sockfile_path.nil?
         root_sockfile_path = File.join @root, '.zeus.sock'
-        @zeus_sockfile_path = if File.exist?(root_sockfile_path)
-                                root_sockfile_path
-                              else
-                                pwd_sockfile_path = File.join Dir.pwd, '.zeus.sock'
-                                pwd_sockfile_path if File.exist?(pwd_sockfile_path)
-                              end
+        if File.exist?(root_sockfile_path) then root_sockfile_path
+        else
+          pwd_sockfile_path = File.join Dir.pwd, '.zeus.sock'
+          pwd_sockfile_path if File.exist?(pwd_sockfile_path)
+        end
+        root_sockfile_path
       end
 
     end


### PR DESCRIPTION
Improves zeus_socket method to check for zeus socket files in both the specified root and also in pwd.  To use this in a test/dummy app, start zeus in the engine's root, then symlink the socket file into test/dummy with `ln -s .zeus.sock test/dummy/.zeus.sock`.