### PR TITLE
Update runner.rb

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -191,7 +191,11 @@ module Guard
       end
 
       def zeus_sockfile
-        File.join(@root, '.zeus.sock')
+        unless ENV['ZEUSSOCK'].to_s.empty?
+          ENV['ZEUSSOCK']
+        else
+          File.join(@root, '.zeus.sock')
+        end
       end
 
     end


### PR DESCRIPTION
Allow different zeus socket file location based on the `ZEUSSOCK` environment variable; this is respected by zeus: https://github.com/burke/zeus/blob/29ca02509c1eb51439b34cd7e37bf4534dca361f/go/unixsocket/unixsocket.go#L76